### PR TITLE
Added respect for :skip-wiki metadata to reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,21 @@ To include only one or more namespaces, set them with the `:include` key:
 ```
 
 Each of these keywords can be used together, of course.
+
+### Skipping Individual Functions
+
+To force codox to skip an individual public var, add `:no-doc true` to the var's metadata. For example,
+
+```clojure
+;; square show up in codox...
+(defn square
+  "Squares the supplied number."
+  [x])
+
+;; but hidden-square won't.
+(defn hidden-square
+  "Squares the supplied number."
+  {:no-doc true}
+  [x]
+  (* x x))
+```

--- a/src/codox/reader.clj
+++ b/src/codox/reader.clj
@@ -20,9 +20,13 @@
        (filter (comp :doc meta))
        (sort-by (comp :name meta))))
 
+(defn- skip-public? [var]
+  (let [{:keys [skip-wiki no-doc]} (meta var)]
+    (or skip-wiki no-doc)))
+
 (defn- read-publics [namespace]
   (for [var (sorted-public-vars namespace)
-        :when (not (:skip-wiki (meta var)))]
+        :when (not (skip-public? var))]
     (-> (meta var)
         (select-keys [:name :file :line :arglists :doc :macro :added])
         (update-in [:doc] correct-indent))))


### PR DESCRIPTION
This change causes codox to skip vars with `:skip-wiki true` in the metadata. (For example, for an operation called `cake`, Cascalog generates `cake` and `cake__` -- this change allows codox to ignore the latter.)
