### PR TITLE
Add :deprecated to the list of metadata extracted for each var

### DIFF
--- a/src/codox/reader.clj
+++ b/src/codox/reader.clj
@@ -28,7 +28,8 @@
   (for [var (sorted-public-vars namespace)
         :when (not (skip-public? var))]
     (-> (meta var)
-        (select-keys [:name :file :line :arglists :doc :macro :added])
+        (select-keys
+         [:name :file :line :arglists :doc :macro :added :deprecated])
         (update-in [:doc] correct-indent))))
 
 (defn- read-ns [namespace]


### PR DESCRIPTION
Makes the :deprecated metadata available for each var.
