### PR TITLE
Enable writer plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To exclude a namespace, use the `:exclude` key:
 
 Sequences work too:
 
-```clojure    
+```clojure
 :codox {:exclude [my.private.ns another.private.ns]
 ```
 
@@ -49,6 +49,13 @@ To write output to a directory other than the default `doc` directory, use the
 
 ```clojure
 :codox {:output-dir "doc/codox"}
+```
+
+To use a different output writer, specify the fully qualified symbol of the
+writer function in the `:writer` key:
+
+```clojure
+:codox {:writer codox.writer.html/write-docs}
 ```
 
 Each of these keywords can be used together, of course.

--- a/src/codox/main.clj
+++ b/src/codox/main.clj
@@ -1,8 +1,20 @@
 (ns codox.main
   "Main namespace for generating documentation"
   (:use [codox.utils :only (ns-filter)]
-        [codox.reader :only (read-namespaces)]
-        [codox.writer.html :only (write-docs)]))
+        [codox.reader :only (read-namespaces)]))
+
+(defn- writer [{:keys [writer]}]
+  (let [writer-sym (or writer 'codox.writer.html/write-docs)
+        writer-ns (symbol (namespace writer-sym))]
+    (try
+      (require writer-ns)
+      (catch Exception e
+        (throw
+         (Exception. (str "Could not load codox writer " writer-ns) e))))
+    (if-let [writer (resolve writer-sym)]
+      writer
+      (throw
+         (Exception. (str "Could not resolve codox writer " writer-sym))))))
 
 (defn generate-docs
   "Generate documentation from source files."
@@ -10,5 +22,6 @@
      (generate-docs {}))
   ([{:keys [sources include exclude] :as options}]
      (let [namespaces (-> (apply read-namespaces sources)
-                          (ns-filter include exclude))]
-       (write-docs (assoc options :namespaces namespaces)))))
+                          (ns-filter include exclude))
+           write (writer options)]
+       (write (assoc options :namespaces namespaces)))))


### PR DESCRIPTION
Allow specification of a :writer symbol in the options map, that is resolved
to obtain the function used to write output.

This is to enable plugins such as https://github.com/hugoduncan/codox-md
