### PR TITLE
Add support for grouping protocol functions

### DIFF
--- a/codox.core/resources/codox/css/default.css
+++ b/codox.core/resources/codox/css/default.css
@@ -166,3 +166,7 @@ h2 {
    display: block;
    color: #008;
 }
+
+.protocol {
+    margin-left: 3em;
+}

--- a/codox.core/src/codox/reader.clj
+++ b/codox.core/src/codox/reader.clj
@@ -18,7 +18,12 @@
   (->> (ns-publics namespace)
        (vals)
        (filter (comp :doc meta))
-       (sort-by (comp :name meta))))
+       (sort-by (fn [v]
+                  (let [{:keys [protocol ns] :as m} (meta v)
+                        vname (name (:name m))]
+                    (if protocol
+                      (str (name (:name (meta protocol))) vname)
+                      vname))))))
 
 (defn- skip-public? [var]
   (let [{:keys [skip-wiki no-doc]} (meta var)]
@@ -29,7 +34,7 @@
         :when (not (skip-public? var))]
     (-> (meta var)
         (select-keys
-         [:name :file :line :arglists :doc :macro :added :deprecated])
+         [:name :file :line :arglists :doc :macro :added :deprecated :protocol])
         (update-in [:doc] correct-indent))))
 
 (defn- read-ns [namespace]

--- a/codox.core/src/codox/writer/html.clj
+++ b/codox.core/src/codox/writer/html.clj
@@ -17,11 +17,19 @@
 (defn- var-uri [namespace var]
   (str (ns-filename namespace) "#" (var-id var)))
 
+(defn- var-classes [var]
+  (->> (select-keys var [:protocol])
+       keys
+       (map name)
+       (str/join ",")))
+
 (defn- link-to-ns [namespace]
   (link-to (ns-filename namespace) [:span (h (:name namespace))]))
 
 (defn- link-to-var [namespace var]
-  (link-to (var-uri namespace var) [:span (h (:name var))]))
+  (link-to
+   (var-uri namespace var)
+   [:span {:class (var-classes var)} (h (:name var))]))
 
 (defn- namespaces-menu [project & [namespace]]
   [:div#namespaces.sidebar
@@ -95,7 +103,8 @@
      [:h2 (h (namespace-title namespace))]
      [:pre.doc (h (:doc namespace))]
      (for [var (:publics namespace)]
-       [:div.public {:id (h (var-id var))}
+       [:div.public {:id (h (var-id var))
+                     :class (var-classes var)}
         [:h3 (h (:name var))]
         [:div.usage
          (for [form (var-usage var)]


### PR DESCRIPTION
Protocol functions are grouped under their respective protocol, and are displayed indented.

My css foo is limited, so the output can be made prettier...
