### PR TITLE
Add option to use a relative path to the source file in the uri to the hosted source

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ to the function's source file in the documentation, you can set the
 `:src-dir-uri` key:
 
 ```clojure
-:codox {:src-dir-uri "http://github.com/clojure/clojure/blob/master"}
+:codox {:src-dir-uri "http://github.com/clojure/clojure/blob/master/"}
 ```
+
+Note: The trailing / is no longer automatically inserted.
 
 Some code hosting sites, such as Github, set an anchor for each line
 of code. If you set the `:src-linenum-anchor-prefix project` key, the
@@ -87,15 +89,8 @@ to the raw line number in the anchors for each line; on Github this is
 "L":
 
 ```clojure
-:codox {:src-dir-uri "http://github.com/clojure/clojure/blob/master"
+:codox {:src-dir-uri "http://github.com/clojure/clojure/blob/master/"
         :src-linenum-anchor-prefix "L"}
-```
-
-If your code hosting site requires a relative path to the source file set the
-`:src-use-relative-path` key:
-
-```clojure
-:codox {:src-use-relative-path true}
 ```
 
 Each of these keywords can be used together, of course.

--- a/codox.core/src/codox/writer/html.clj
+++ b/codox.core/src/codox/writer/html.clj
@@ -19,7 +19,6 @@
 
 (defn- var-source-uri [src-dir-uri var anchor-prefix use-relative-path]
   (str src-dir-uri
-       (if (or (= (last src-dir-uri) \/) use-relative-path) "" "/")
        (:path var)
        (if anchor-prefix
          (str "#" anchor-prefix (:line var)))))


### PR DESCRIPTION
Our local code hosting requires URI similar to:

hb=HEAD;f=src/main/clojure/rulethemall/models/batch.clj

Therefore an override to obtain the source path without a leading / is required.
