### PR TITLE
fix "Generated by Codox" width problem (firefox)

### DIFF
--- a/codox.core/resources/codox/css/default.css
+++ b/codox.core/resources/codox/css/default.css
@@ -102,8 +102,7 @@ h2 {
     float: right;
     font-size: 9pt;
     font-weight: normal;
-    width: 10em;
-    margin: 3px 0;
+    margin: 3px 3px;
     color: #bbb;
 }
 


### PR DESCRIPTION
The original style looks like this in firefox:

<a href="http://imgur.com/odMWp46"><img src="http://i.imgur.com/odMWp46.png" alt="" title="Hosted by imgur.com" /></a>

The proposed fix has been tested to work in both firefox and chrome.
