### PR TITLE
Ns index summary

### DIFF
--- a/codox.core/src/codox/utils.clj
+++ b/codox.core/src/codox/utils.clj
@@ -69,3 +69,12 @@
       :publics
       (map #(assoc % :path (find-file-in-repo (:file %) (or sources ["src"])))
            (:publics ns)))))
+
+(defn summary
+  "Return the summary of a docstring.
+   The summary is the first portion of the string, from the first
+   character to the first page break (\f) character OR the first TWO
+   newlines."
+  [s]
+  (->> (str/trim s)
+       (re-find #"(?s).*?(?=\f)|.*?(?=\n\n)|.*")))

--- a/codox.core/src/codox/writer/html.clj
+++ b/codox.core/src/codox/writer/html.clj
@@ -3,7 +3,8 @@
   (:use [hiccup core page element])
   (:import java.net.URLEncoder)
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [codox.utils :as util]))
 
 (defn- ns-filename [namespace]
   (str (:name namespace) ".html"))
@@ -78,7 +79,7 @@
      (for [namespace (:namespaces project)]
        [:div.namespace
         [:h3 (link-to-ns namespace)]
-        [:pre.doc (h (:doc namespace))]
+        [:pre.doc (h (util/summary (:doc namespace)))]
         [:div.index
          [:p "Public variables and functions:"]
          (var-links namespace)]])]]))


### PR DESCRIPTION
Forked from [this PR](https://github.com/weavejester/codox/pull/25/files).

```
codox.utils=> (summary "Test")
"Test"
codox.utils=> (summary "Test\n\nX")
"Test"
codox.utils=> (summary "Test\n\n\nX")
"Test"
codox.utils=> (summary "\nTest\n\n\nX")
"Test"
codox.utils=> (summary "Test\fX")
"Test"
```
