### PR TITLE
Skip namespaces with :no-doc metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ add a mapping like:
 
 ### Metadata Options
 
-To force Codox to skip a public var, add `:no-doc true` to the var's
-metadata. For example:
+To force Codox to skip a public var, add `:no-doc true`
+to the var's metadata. For example:
 
 ```clojure
 ;; Documented
@@ -144,6 +144,14 @@ metadata. For example:
   "Squares the supplied number."
   [x]
   (* x x))
+```
+
+You can also skip namespaces by adding `:no-doc true` to the
+namespace's metadata. *This currently only works for Clojure code, not
+ClojureScript.* For example:
+
+```clojure
+(ns ^:no-doc hidden-ns)
 ```
 
 To denote the library version the var was added in, use the `:added`

--- a/codox.core/src/codox/reader/clojure.clj
+++ b/codox.core/src/codox/reader/clojure.clj
@@ -88,6 +88,8 @@
   \"src\"), and return a list of maps suitable for documentation
   purposes.
 
+  Any namespace with {:no-doc true} in its metadata will be skipped.
+
   The keys in the maps are:
     :name   - the name of the namespace
     :doc    - the doc-string on the namespace
@@ -105,6 +107,7 @@
   ([path]
      (->> (io/file path)
           (find-namespaces)
-          (mapcat read-ns)))
+          (mapcat read-ns)
+          (remove :no-doc)))
   ([path & paths]
      (mapcat read-namespaces (cons path paths))))

--- a/codox.example/src/clojure/codox/hidden.clj
+++ b/codox.example/src/clojure/codox/hidden.clj
@@ -1,0 +1,6 @@
+(ns ^:no-doc codox.hidden
+    "This ns shouldn't show in the docs.")
+
+(defn foo
+  "Since the ns is hidden, this var is as well."
+  [])


### PR DESCRIPTION
This extends the ^:no-doc feature for vars to namespaces, causing them
to be ignored entirely. The same change has been made to the clojure and
clojurescript reader, but only the clojure reader has been (manually)
tested.
