### PR TITLE
Simple responsive view

### DIFF
--- a/codox.core/resources/codox/css/default.css
+++ b/codox.core/resources/codox/css/default.css
@@ -453,3 +453,28 @@ p {
     text-decoration: none;
     color: #5555bb;
 }
+
+@media (max-width: 600px) {
+
+  body {
+    margin: 0;
+  }
+
+  #header, #content, .sidebar {
+     position: static;
+  }
+
+  #header {
+    height: auto;
+  }
+  .sidebar {
+    overflow: visible;
+    width: auto !important;
+  }
+  #content {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+}
+

--- a/codox.core/resources/codox/js/page_effects.js
+++ b/codox.core/resources/codox/js/page_effects.js
@@ -72,6 +72,10 @@ function sidebarContentWidth(element) {
 }
 
 function resizeSidebars() {
+    if ($('body').width() < 500) {
+        return;
+    }
+
     var nsWidth  = sidebarContentWidth('#namespaces') + 30
     var varWidth = 0
 

--- a/codox.core/src/codox/writer/html.clj
+++ b/codox.core/src/codox/writer/html.clj
@@ -171,6 +171,8 @@
 (def ^{:private true} default-includes
   (list
    [:meta {:charset "UTF-8"}]
+   [:meta {:name "viewport" :content "width=device-width"}]
+
    (include-css "css/default.css")
    (include-js "js/jquery.min.js")
    (include-js "js/page_effects.js")))


### PR DESCRIPTION
As discussed in #35 

I've not added any fancy collapsing of the menus, simply clicking the anchors seems to work reasonably well in my testing.

Tested on Desktop Firefox in responsive mode and iOS 7 - should be pretty safe though, I've not done anything particularly out-there.
