### PR TITLE
Do not ignore 'imported' protocol method vars

### DIFF
--- a/codox.core/src/codox/reader/clojure.clj
+++ b/codox.core/src/codox/reader/clojure.clj
@@ -28,8 +28,9 @@
   (let [value (var-get var)]
     (and (map? value) (:on-interface value))))
 
-(defn- protocol-method? [var]
-  (:protocol (meta var)))
+(defn- protocol-method? [vars var]
+  (if-let [p (:protocol (meta var))]
+    (some #{p} vars)))
 
 (defn- protocol-methods [protocol vars]
   (filter #(= protocol (:protocol (meta %))) vars))
@@ -55,7 +56,7 @@
     (->> vars
          (remove proxy?)
          (remove no-doc?)
-         (remove protocol-method?)
+         (remove (partial protocol-method? vars))
          (map (partial read-var vars))
          (sort-by (comp str/lower-case :name)))))
 

--- a/codox.example/src/clojure/codox/import.clj
+++ b/codox.example/src/clojure/codox/import.clj
@@ -1,0 +1,8 @@
+(ns codox.import
+  (:require [codox.example :as ex]))
+
+(defn foop
+  [& args]
+  (apply ex/foop args))
+
+(alter-meta! #'foop merge (meta #'ex/foop))


### PR DESCRIPTION
[potemkin][1] can import vars into a namespace, copying their complete metadata. This means that there might be protocol method vars in one namespace while the corresponding protocol can be found in a different one.

Codox currently filters out those vars because it expects to attach them directly to the protocol's documentation data. (see also ztellman/potemkin#25) This MR adjusts the logic to retain all those protocol functions (or generally all vars with `^:protocol` metadata) that can not be matched against a protocol in the same namespace.

[1]: https://github.com/ztellman/potemkin