### PR TITLE
Fix for creating docs for Om projects

### DIFF
--- a/codox.core/project.clj
+++ b/codox.core/project.clj
@@ -6,6 +6,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.namespace "0.2.4"]
-                 [org.clojure/clojurescript "0.0-2234"]
+                 [org.clojure/clojurescript "0.0-2913"]
                  [hiccup "1.0.5"]
                  [org.pegdown/pegdown "1.4.2"]])


### PR DESCRIPTION
@weavejester This fixes creating docs for Om projects that use ```[org.omcljs/om "0.8.8"]```

Om now includes ```cljsjs/react``` as a dependency which does not have ```clj``` files. This causes the ClojureSript analyzer to fail.

Line 63 in ```clojurescript.clj``` rebinds ```*analyze-deps*``` to false. This allows me to create docs for my Om projects, though a ton of warnings are still produced.

The other changes are from my previous PR.