### PR TITLE
generate user documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 0.8.14 (2015-08-29)
+
+* If `doc/intro.md` exists, it will be used as the body of the
+  index/"Introduction" page. The page can be changed via `:intro-page` 
+  
 ## 0.8.13 (2015-07-11)
 
 * Updated tools.namespace to support .cljc files in Clojure 1.7

--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ add a mapping like:
 
 (Note that the ending "/" is required in "src/".)
 
+### User Documentation
+
+It's often useful to provide user documentation such as overviews,
+getting started pages, tutorials, and user guides in addition to api
+docs generated from the source.
+
+By default, if a `doc/intro.md` file exists it will be used as the
+body of the main index page.
+
+To change the intro page to a different file, use the `:intro-page`
+key. For example, to use `README.md` as the intro page: 
+
+```clojure
+:codox {:output-dir "README.md"}
+```
 
 ## Metadata Options
 

--- a/codox.core/project.clj
+++ b/codox.core/project.clj
@@ -1,4 +1,4 @@
-(defproject codox/codox.core "0.8.13"
+(defproject codox/codox.core "0.8.14"
   :description "Generate documentation from Clojure source files"
   :url "https://github.com/weavejester/codox"
   :scm {:dir ".."}

--- a/codox.core/src/codox/main.clj
+++ b/codox.core/src/codox/main.clj
@@ -63,7 +63,8 @@
    :root       (System/getProperty "user.dir")
    :sources    ["src"]
    :output-dir "doc"
-   :defaults   {}})
+   :defaults   {}
+   :intro-page "doc/intro.md"})
 
 (defn generate-docs
   "Generate documentation from source files."

--- a/codox.leiningen/project.clj
+++ b/codox.leiningen/project.clj
@@ -1,4 +1,4 @@
-(defproject codox/codox.leiningen "0.8.13"
+(defproject codox/codox.leiningen "0.8.14"
   :description "Codox Leiningen plugin"
   :url "https://github.com/weavejester/codox"
   :scm {:dir ".."}

--- a/codox.leiningen/src/leiningen/doc.clj
+++ b/codox.leiningen/src/leiningen/doc.clj
@@ -19,7 +19,7 @@
                   (project/merge-profiles project [:codox])
                   project)]
     (eval/eval-in-project
-     (deps/add-if-missing project '[codox/codox.core "0.8.13"])
+     (deps/add-if-missing project '[codox/codox.core "0.8.14"])
      `(codox.main/generate-docs
        (update-in '~(get-options project) [:src-uri-mapping] eval))
      `(require 'codox.main))))

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject codox "0.8.13"
+(defproject codox "0.8.14"
   :description "Alias for the codox/codox.leiningen plugin"
   :url "https://github.com/weavejester/codox"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[codox/codox.leiningen "0.8.13"]]
+  :dependencies [[codox/codox.leiningen "0.8.14"]]
   :eval-in-leiningen true)


### PR DESCRIPTION
Just in case anyone is interested, here's a way to include some user documentation (like getting started pages, overviews, tutorials, etc.) alongside api docs. If a project contains `doc/intro.md`, then an "Introduction" link will appear above "Namespaces" on the namespaces sidebar and the contents of intro.md will appear inside the main content area div.

The landing page can be configured using a `:intro-page` key. For example, `codox {:intro-page README.md}` will display the html from README.md in the main div area. 

If doc/intro.md doesn't exist, then codox will generate normal api page (no "Introduction Link" will appear).