### PR TITLE
Allow arbitrary markup to be appended to HTML writer's <head>

### DIFF
--- a/codox/project.clj
+++ b/codox/project.clj
@@ -8,5 +8,6 @@
                  [org.clojure/tools.namespace "0.2.11"]
                  [org.clojure/clojurescript "1.7.189"]
                  [hiccup "1.0.5"]
+                 [enlive "1.1.6"]
                  [org.pegdown/pegdown "1.6.0"]
                  [org.ow2.asm/asm-all "5.0.3"]])


### PR DESCRIPTION
My use case for this is enabling client-side syntax highlighting of fenced code blocks, which is pretty easy w/ this change.

```clojure
{:source-paths ["src"]
 :metadata {:doc/format :markdown}
 :html-writer
 {:head ~(list
          [:link {:rel "stylesheet"
                  :href (str hljs-prefix "styles/default.min.css")}]
          [:script {:src (str hljs-prefix "highlight.min.js")}]
          [:script "hljs.initHighlightingOnLoad()"])}}

```

(where `hljs-prefix` is "//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/", if anyone's curious)

I don't really understand the details of how different concrete collection types are treated by Hiccup, but lists appear to do what was intended - please let me know if this approach is unsatisfactory.

This could also resolve #111, assuming there isn't a need to omit the default stylesheet from the resulting document.