### PR TITLE
Add support for core.typed

### DIFF
--- a/codox/src/codox/reader/clojure.clj
+++ b/codox/src/codox/reader/clojure.clj
@@ -1,10 +1,29 @@
 (ns codox.reader.clojure
   "Read raw documentation information from Clojure source directory."
-  (:import java.util.jar.JarFile)
+  (:import java.util.jar.JarFile
+           java.io.FileNotFoundException)
   (:use [codox.utils :only (assoc-some update-some correct-indent)])
   (:require [clojure.java.io :as io]
             [clojure.tools.namespace.find :as ns]
             [clojure.string :as str]))
+
+(defn try-require [namespace]
+  (try
+    (require namespace)
+    (catch FileNotFoundException _ nil)))
+
+(defn core-typed? []
+  (find-ns 'clojure.core.typed.check))
+
+(defn var->symbol [var]
+  (let [{:keys [ns name]} (meta var)]
+    (symbol (str ns) (str name))))
+
+(defn typecheck-namespace [namespace]
+  ((find-var 'clojure.core.typed/check-ns-info) namespace))
+
+(defn typecheck-var [var]
+  ((find-var 'clojure.core.typed/check-form-info) (var->symbol var)))
 
 (defn- sorted-public-vars [namespace]
   (->> (ns-publics namespace)
@@ -44,12 +63,18 @@
    (protocol? var)    :protocol
    :else              :var))
 
+(defn core-typed-type [var]
+  (let [{:keys [delayed-errors ret]} (typecheck-var var)]
+    (if (empty? delayed-errors)
+      (:t ret))))
+
 (defn- read-var [vars var]
   (-> (meta var)
       (select-keys [:name :file :line :arglists :doc :dynamic
                     :added :deprecated :doc/format])
       (update-some :doc correct-indent)
-      (assoc-some  :type    (var-type var)
+      (assoc-some  :type (var-type var)
+                   :type-sig (if (core-typed?) (core-typed-type var))
                    :members (seq (map (partial read-var vars)
                                       (protocol-methods var vars))))))
 
@@ -63,6 +88,9 @@
          (sort-by (comp str/lower-case :name)))))
 
 (defn- read-ns [namespace]
+  (try-require 'clojure.core.typed.check)
+  (when (core-typed?)
+    (typecheck-namespace namespace))
   (try
     (require namespace)
     (-> (find-ns namespace)

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -352,6 +352,9 @@
    [:div.usage
     (for [form (var-usage var)]
       [:code (h (pr-str form))])]
+   (if (:type-sig var)
+     [:div.type-sig
+      [:code (h (pr-str (:type-sig var)))]])
    [:div.doc (format-docstring project namespace var)]
    (if-let [members (seq (:members var))]
      [:div.members

--- a/example/project.clj
+++ b/example/project.clj
@@ -20,12 +20,15 @@
                  [:pre.deps] [:before [:p "Before test"]]
                  [:pre.deps] [:after  [:p "After test"]]]}}
   :profiles
-  {:md   {:codox {:metadata {:doc/format :markdown}}}
-   :cljs {:dependencies [[org.clojure/clojure "1.7.0"]
-                         [org.clojure/clojurescript "1.7.189"]]
-          :codox {:language :clojurescript}}
-   :om   {:dependencies [[org.omcljs/om "0.8.8"]]}
+  {:md     {:codox {:metadata {:doc/format :markdown}}}
+   :cljs   {:dependencies [[org.clojure/clojure "1.7.0"]
+                           [org.clojure/clojurescript "1.7.189"]]
+            :codox {:language :clojurescript}}
+   :om     {:dependencies [[org.omcljs/om "0.8.8"]]}
+   :typed  {:dependencies [[org.clojure/clojure "1.7.0"]
+                           [org.clojure/core.typed "0.3.22"]]
+            :plugins [[lein-typed "0.3.5"]]
+            :source-paths ^:replace ["src-typed/clojure"]}
    :no-src {:codox ^:replace {}}
    :no-doc {:codox {:doc-paths ^:replace []}}
-   :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
-   :flat {:codox {:html {:namespace-list :flat}}}})
+   :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}})

--- a/example/src-typed/clojure/codox/example.clj
+++ b/example/src-typed/clojure/codox/example.clj
@@ -1,0 +1,28 @@
+(ns codox.example
+  "This is an example namespace for testing.
+
+  Some more detailed description down here.
+
+  An inline link: http://example.com
+  An inline HTTPS link: https://example.com"
+  {:added "1.1"}
+  (:require [clojure.core.typed :as t]))
+
+(defn foo
+  "This is an example function for foo."
+  ([x])
+  ([x y & z]))
+
+(defn bar
+  "This is an example function for deprecated bar."
+  {:deprecated "2.0"}
+  ([x])
+  ([x y & z]))
+
+(defn ^:no-doc hidden [x])
+
+(defn markfoo
+  "A docstring that uses **markdown**.
+  See [[foo]], and also [[typed.array/sum]]."
+  {:doc/format :markdown}
+  [x])

--- a/example/src-typed/clojure/codox/typed/array.clj
+++ b/example/src-typed/clojure/codox/typed/array.clj
@@ -1,0 +1,41 @@
+(ns codox.typed.array
+  (:require [clojure.core.typed :refer [ann check-ns into-array> cf print-env ann-form]
+             :as t]
+            [clojure.repl :refer [pst]]))
+
+(ann my-integer-array [-> (Array Integer)])
+(defn my-integer-array [] (into-array> Integer (map int [1 2])))
+
+(ann my-int-array [-> (Array int)])
+(defn my-int-array [] (into-array> int (map int [1 2])))
+
+(ann sum [(ReadOnlyArray Number) -> Number])
+(defn sum [arr]
+  (t/loop [idx :- long 0,
+           ret :- Number 0]
+    (if (< idx (alength arr))
+      (recur 
+        (unchecked-inc idx) 
+        (+ (aget arr idx) ret))
+      ret)))
+
+(fn [] (sum (my-integer-array)))
+
+(ann write-integer-to-zero [(Array2 Integer t/Any) -> nil])
+(defn write-integer-to-zero [arr]
+  (aset arr 0 (int 12))
+  nil)
+
+(ann write-int-to-zero [(Array2 int t/Any) -> nil])
+(defn write-int-to-zero [arr]
+  (aset arr 0 (int 12))
+  nil)
+
+(fn [] (write-integer-to-zero my-integer-array))
+(fn [] (write-int-to-zero (my-int-array)))
+
+(ann bad-modify-array [(Array Number) -> nil])
+#_(defn bad-modify-array [ar]
+  (let [ar2 (ann-form ar (Array2 Number Object))]
+    (aset ar2 0 (new java.util.Observable))
+    nil))

--- a/example/src-typed/clojure/codox/typed/defproto.clj
+++ b/example/src-typed/clojure/codox/typed/defproto.clj
@@ -1,0 +1,34 @@
+(ns codox.typed.defproto
+  (:refer-clojure :exclude [defprotocol fn])
+  (:require [clojure.core.typed :as t :refer [defprotocol fn Int Num]]))
+
+(defprotocol Foo
+  (is-foo [this, a :- Num] :- Num)
+  (is-bar [this, a :- Int] :- Int
+          [this, b :- Num] :- Num)
+  (is-baz [this, a :- Int] :- Int
+          [this, a :- Int, b :- Int] :- Int
+          [this, a :- Int, b :- Int, c :- Int] :- Int))
+
+(defprotocol DocD
+  "This is a docstring"
+  (docd [this, a :- Num] :- Num
+        "trailing docstring"))
+
+(fn [a :- Foo]
+  (is-foo a 1))
+
+(fn [a :- Foo] :- Int
+  (is-bar a 1))
+
+(fn [a :- Foo] :- Num
+  (is-bar a 1.1))
+
+(fn [a :- Foo] :- Int
+  (is-baz a 1))
+
+(fn [a :- Foo] :- Int
+  (is-baz a 1 1))
+
+(fn [a :- Foo] :- Int
+  (is-baz a 1 1 1))


### PR DESCRIPTION
Most of this work was previously done by @atroche.

Additionally, the following tasks have been contributed by @oubiwann:

* Rewrote var->symbol.
  (Made change per suggestion of @weavejester.
  See: https://github.com/weavejester/codox/pull/82#discussion-diff-24142557)

* Fixed output div for core.typed.
  (This issue was identified by @weavejester in this comment:
   https://github.com/weavejester/codox/pull/82/files#r24138719)

* Added a src dir for typed example code.
  (All of the new additions were taken from core.typed unit tests.)

To generate the typed example project:
  lein with-profile +typed codox
