### PR TITLE
Add boot task for codox

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ source code.
 
 ## Usage
 
+### Leiningen
+
 Include the following plugin in your `project.clj` file or your global
 profile:
 
@@ -22,6 +24,31 @@ lein codox
 This will generate API documentation in the "target/doc" subdirectory
 (or wherever your project `:target-path` is set to).
 
+### Boot
+
+Add boot-codox to your build.boot dependencies and require the namespace:
+```
+(set-env! :dependencies '[[boot-codox "0.9.4" :scope "test"]])
+(require '[codox.boot :refer [codox]])
+```
+
+You can see the options available on the command line:
+
+```
+$ boot codox -h
+```
+
+or in the REPL:
+
+```
+boot.user=> (doc codox)
+```
+
+Remember to output files to the target directory with boot's built-in `target` task:
+
+```
+$ boot codox target
+```
 
 ## Breaking Changes in 0.9
 

--- a/boot-codox/project.clj
+++ b/boot-codox/project.clj
@@ -1,0 +1,6 @@
+(defproject boot-codox "0.9.4"
+  :description "Codox Boot task"
+  :url "https://github.com/weavejester/codox"
+  :scm {:dir ".."}
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"})

--- a/boot-codox/src/codox/boot.clj
+++ b/boot-codox/src/codox/boot.clj
@@ -1,0 +1,59 @@
+(ns codox.boot
+  {:boot/export-tasks true}
+  (:require [clojure.java.io :as io]
+            [boot.core :as core :refer [deftask]]
+            [boot.pod :as pod]
+            [boot.util :as util]))
+
+(defn- pod-deps
+  []
+  (remove pod/dependency-loaded? '[[codox "0.9.4"]]))
+
+(defn- init
+  [fresh-pod]
+  (pod/require-in fresh-pod '[codox.main]))
+
+(deftask codox
+  "Generate documentation in a pod."
+  [n  name                STRING str    "The project name"
+   v  version             STRING str    "The project version"
+   o  output-path         PATH   str    "The directory where the documentation will be generated"
+   s  source-paths        PATHS  #{str} "Source paths from which to create documentation (defaults to :source-paths in Boot env)"
+   u  source-uri          URI    str    "Source URI template string"
+   d  doc-paths           PATHS  #{str} "Path to documentation files"
+   l  language            LANG   kw     "Library language. (defaults to :clojure)"
+   f  filter-namespaces   NS     #{sym} "Namespace restriction for documentation generation (defaults to all namespaces)"
+   w  writer              WRITER sym    "Custom output writer"]
+  (when-not name
+    (util/fail "No codox project name specified\n")
+    (System/exit 1))
+
+  (let [output-path (or output-path "doc")
+        source-paths (or source-paths (:source-paths (core/get-env)))
+        updated-env (update (core/get-env) :dependencies into (pod-deps))
+        pods (pod/pod-pool updated-env :init init)]
+    (core/cleanup (pods :shutdown))
+    (core/with-pre-wrap fileset
+      (let [worker-pod (pods :refresh)
+            tmp-dir (core/tmp-dir!)
+            docs-dir (io/file tmp-dir output-path)]
+
+        (pod/with-eval-in worker-pod
+          (->> {:name ~name
+                :version ~version
+                :source-paths ~source-paths
+                :output-path ~(.getPath docs-dir)
+                :source-uri ~source-uri
+                :doc-paths ~doc-paths
+                :language ~language
+                :namespaces (quote ~filter-namespaces)
+                :writer (quote ~writer)}
+            ;; Remove unspecified options
+            (into {} (remove (comp nil? second)))
+            (codox.main/generate-docs)))
+
+        (util/info (str "Generated HTML docs in " output-path "\n"))
+
+        (-> fileset
+          (core/add-asset tmp-dir)
+          (core/commit!))))))

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -435,5 +435,4 @@
     (copy-resource "codox/js/page_effects.js" "js/page_effects.js")
     (write-index project)
     (write-namespaces project)
-    (write-documents project))
-  (println "Generated HTML docs in" (.getAbsolutePath (io/file output-path))))
+    (write-documents project)))

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,0 +1,13 @@
+(set-env!
+  :source-paths #{"src/clojure"}
+  :dependencies '[[boot-codox "0.9.4"]])
+
+(require '[codox.boot :refer [codox]])
+
+(deftask docs []
+  (comp
+    (codox
+      :name "Example Project"
+      :version "1.0.0"
+      :source-uri "https://github.com/weavejester/codox/blob/{version}/codox.example/{filepath}#L{basename}-{line}")
+    (target)))

--- a/lein-codox/src/leiningen/codox.clj
+++ b/lein-codox/src/leiningen/codox.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [leiningen.core.project :as project]
+            [leiningen.core.main :as main]
             [leinjacker.deps :as deps]
             [leinjacker.eval :as eval]))
 
@@ -20,8 +21,10 @@
   [project]
   (let [project (if (get-in project [:profiles :codox])
                   (project/merge-profiles project [:codox])
-                  project)]
+                  project)
+        options (get-options project)]
     (eval/eval-in-project
      (deps/add-if-missing project '[codox "0.9.4"])
-     `(codox.main/generate-docs '~(get-options project))
-     `(require 'codox.main))))
+     `(codox.main/generate-docs '~options)
+     `(require 'codox.main))
+    (main/info "Generated HTML docs in" (:output-path options))))


### PR DESCRIPTION
## Testing
In the `example` subdirectory, you can run:
```
$ boot codox -h
```
to list the task options.

## Missing features from lein-codox
- Regular expression namespace filtering (still deciding on best way to
reconcile polymorphic filters with boot's task option type casting)
- Default metadata (will ask boot dev team about passing clojure data
structures as task option)
- HTML transformations (ditto reason)
- source-uri templates (ditto)

## Notes
When codox is running through boot, it prints out a message like:
```
Generated HTML docs in
~/.boot/cache/tmp/Users/adam/open-source/codox/example/1noy/-pm147t/doc
```
which needlessly shows the boot temp file being written to, which is a
mild annoyance.

Let me know if you have any thoughts about the approach, or if you would like me to add anything to make it easier for you to test and verify.