### PR TITLE
Add :metadata option to Boot task

### DIFF
--- a/boot-codox/src/codox/boot.clj
+++ b/boot-codox/src/codox/boot.clj
@@ -23,6 +23,7 @@
    d  doc-paths           PATHS  #{str} "Path to documentation files"
    l  language            LANG   kw     "Library language. (defaults to :clojure)"
    f  filter-namespaces   NS     #{sym} "Namespace restriction for documentation generation (defaults to all namespaces)"
+   m  metadata            META   edn    "Metadata settings in edn format"
    w  writer              WRITER sym    "Custom output writer"]
   (when-not name
     (util/fail "No codox project name specified\n")
@@ -47,6 +48,7 @@
                 :doc-paths ~doc-paths
                 :language ~language
                 :namespaces (quote ~filter-namespaces)
+                :metadata ~metadata
                 :writer (quote ~writer)}
             ;; Remove unspecified options
             (into {} (remove (comp nil? second)))


### PR DESCRIPTION
Accepts an edn argument, so you can do something like `boot codox -m
'{:doc/format :markdown}'`. Another option would be to use key=val, but
that's more complex[1], so I opted for the simpler approach of just
keeping it in edn. Let me know @weavejester which you like better.

This PR goes along nicely with #130 :smiley: 

[1]: https://github.com/boot-clj/boot/wiki/Task-Options-DSL#complex-options