### PR TITLE
Ignore extraneous indentation when rendering MD

### DIFF
--- a/example/src/clojure/codox/markdown.clj
+++ b/example/src/clojure/codox/markdown.clj
@@ -1,36 +1,54 @@
 (ns codox.markdown
-  "This is an example of a namespace written in markdown, rather than the usual
+  "## Markdown - headers, text and inline markup
+
+  This is an example of a namespace written in markdown, rather than the usual
   plaintext format.
 
   We're going to cover all the standard formatting, like *italics*, **bolds**,
   `:inline-code` ~~strikethrough~~ and \"smart quotes\" -- so we can check the
   styling in the docs.
 
+  ## Lists
+
+  ### Unordered lists
+
   - Let's check
   - unordered
   - lists
 
+  ### Ordered lists
+
   1. And let's also check
   2. ordered
   2. lists
+
+  ## Code blocks
 
   We should also check code block formatting:
 
       (defn foo [x]
         (+ x 1))
 
+  ## Links
+
   [Inline links](http://example.com) and [reference links][1].
 
   [1]: http://example.com
 
+  ## Extensions
+
+  ### URLs
+
   Extensions like auto-linked URLs (http://example.com) and tabular data:
+
+  ### Tables
 
   foo | bar
   ----|----
-   1  |  2 
+   1  |  2
    3  |  4
 
-  Definition lists:
+  ### Definition lists
 
   foo
   : a variable
@@ -42,8 +60,12 @@
   : a longer description that goes on for several lines, demonstrating that
     terms in a definition list can have definitions that span multiple lines.
 
+  ### Wikilinks
+
   We can also use wikilinks to reference existing vars, like [[example/foo]] or
   the [[Foop]] protocol, or to reference namespaces, like [[codox.example]].
+
+  ### Abbreviations
 
   Any abbreviations, like HTML or HTTP, that have corresponding abbreviations,
   will be marked with `<abbr>` tags.


### PR DESCRIPTION
This allows vertically aligning/indenting docstrings in source code
while still allowing the use of ## headers and other markdown formatting
features that must start at the beginning of a line.

In my particular case, this means that emacs's very nice lisp indenting
functions won't break my markdown formatted (ns ..) docstrings.