### PR TITLE
Include clojure.spec specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,19 @@ For example, perhaps your Clojure source files are generated in
 
 [cljx]: https://github.com/lynaghk/cljx
 
+### Namespace aliases for clojure.spec
+
+Codox looks for any [`clojure.spec`](http://clojure.org/about/spec) specs
+registered on vars or keywords in the project namespaces. Since specs use
+fully-qualified keywords they can be verbose. You can provide namespace aliases
+to abbreviate them:
+
+```clojure
+:codox {:ns-aliases {com.acme-widgets.stuff stuff, foo.protocols p}}
+```
+
+Note that spec keywords are printed with `::` syntax within their own namespace.
+
 ### HTML Transformations
 
 The HTML writer can be customized using [Enlive][]-style

--- a/codox/resources/codox/theme/default/css/default.css
+++ b/codox/resources/codox/theme/default/css/default.css
@@ -387,6 +387,14 @@ h4.deprecated {
     padding-left: 0;
 }
 
+.spec {
+    clear: both;
+}
+
+.spec dt {
+    font-weight: bold;
+}
+
 .type-sig {
     clear: both;
     color: #088;

--- a/codox/src/codox/reader/clojure.clj
+++ b/codox/src/codox/reader/clojure.clj
@@ -12,6 +12,9 @@
     (require namespace)
     (catch FileNotFoundException _ nil)))
 
+(defn clojure-spec? []
+  (find-ns 'clojure.spec))
+
 (defn core-typed? []
   (find-ns 'clojure.core.typed.check))
 
@@ -63,6 +66,15 @@
    (protocol? var)    :protocol
    :else              :var))
 
+(defn clojure-spec-form [var]
+  (let [spec ((find-var 'clojure.spec/get-spec) var)
+        describe (find-var 'clojure.spec/describe)]
+    (if (or (:args spec) (:ret spec))
+      {:args (if-let [x (:args spec)] (describe x))
+       :ret (if-let [x (:ret spec)] (describe x))
+       :fn (if-let [x (:fn spec)] (describe x))}
+      (if spec (describe spec)))))
+
 (defn core-typed-type [var]
   (let [{:keys [delayed-errors ret]} (typecheck-var var)]
     (if (empty? delayed-errors)
@@ -74,6 +86,7 @@
                     :added :deprecated :doc/format])
       (update-some :doc correct-indent)
       (assoc-some  :type (var-type var)
+                   :spec (if (clojure-spec?) (clojure-spec-form var))
                    :type-sig (if (core-typed?) (core-typed-type var))
                    :members (seq (map (partial read-var vars)
                                       (protocol-methods var vars))))))
@@ -87,7 +100,20 @@
          (map (partial read-var vars))
          (sort-by (comp str/lower-case :name)))))
 
+(defn- read-kw-specs [ns]
+  (let [describe (find-var 'clojure.spec/describe)
+        reg ((find-var 'clojure.spec/registry))
+        ids (->> reg
+                 keys
+                 (filter keyword?)
+                 (filter (comp #{(name ns)} namespace)))]
+    (->> (select-keys reg ids)
+         (map (fn [[k v]] (merge (meta v) {:name (name k)
+                                           :spec (describe v)})))
+         (sort-by (comp str/lower-case :name)))))
+
 (defn- read-ns [namespace]
+  (try-require 'clojure.spec)
   (try-require 'clojure.core.typed.check)
   (when (core-typed?)
     (typecheck-namespace namespace))
@@ -97,6 +123,7 @@
         (meta)
         (assoc :name namespace)
         (assoc :publics (read-publics namespace))
+        (assoc :kw-specs (if (clojure-spec?) (read-kw-specs namespace)))
         (update-some :doc correct-indent)
         (list))
     (catch Exception e
@@ -134,8 +161,13 @@
       :arglists   - the arguments the function or macro takes
       :doc        - the doc-string of the var
       :type       - one of :macro, :protocol, :multimethod or :var
+      :spec       - any registered spec form for the var symbol
       :added      - the library version the var was added in
-      :deprecated - the library version the var was deprecated in"
+      :deprecated - the library version the var was deprecated in
+    :kw-specs
+      :name       - the name of the keyword under which the spec is registered
+      :spec       - the spec form
+      :line       - the line at which the spec was declared"
   ([] (read-namespaces "src"))
   ([path]
      (->> (io/file path)

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -48,6 +48,9 @@
 (defn- var-id [var]
   (str "var-" (-> var name URLEncoder/encode (str/replace "%" "."))))
 
+(defn- spec-id [name]
+  (str "spec-" (-> name URLEncoder/encode (str/replace "%" "."))))
+
 (def ^:private url-regex
   #"((https?|ftp|file)://[-A-Za-z0-9+()&@#/%?=~_|!:,.;]+[-A-Za-z0-9+()&@#/%=~_|])")
 
@@ -137,6 +140,9 @@
 
 (defn- var-uri [namespace var]
   (str (ns-filename namespace) "#" (var-id (:name var))))
+
+(defn- spec-uri [namespace name]
+  (str (ns-filename namespace) "#" (spec-id name)))
 
 (defn- get-source-uri [source-uris path]
   (some (fn [[re f]] (if (re-find re path) f)) source-uris))
@@ -275,7 +281,15 @@
               class   (if branch? "depth-2 branch" "depth-2")
               inner   [:div.inner (ns-tree-part 0) [:span (h (:name mem))]]]
           [:li {:class class}
-           (link-to (var-uri namespace mem) inner)]))))]])
+           (link-to (var-uri namespace mem) inner)]))))]
+   (when (seq (:kw-specs namespace))
+     [:div
+      [:h3 (link-to "#specs" [:span.inner "Specs"])]
+      [:ul
+       (for [kw-spec (:kw-specs namespace)]
+         [:li.depth-1
+          (link-to (spec-uri namespace (:name kw-spec))
+                   [:div.inner [:span (h (str "::" (:name kw-spec)))]])])]])])
 
 (def ^:private default-meta
   [:meta {:charset "UTF-8"}])
@@ -380,6 +394,47 @@
          (walk/postwalk #(remove-namespaces % implied-namespaces))
          (pprint-str))))
 
+(defn- kw-spec-link [text kw ns-info]
+  (html (link-to (spec-uri ns-info (name kw)) text)))
+
+(defrecord AbbrKeywordLink [kw abbr-ns ns-info]
+  Object
+  (toString [_]
+    (if abbr-ns
+      (str "::" abbr-ns (when (not= abbr-ns "") "/") (name kw))
+      (str kw))))
+
+(defmethod print-method AbbrKeywordLink [ak ^java.io.Writer w]
+  (let [s (h (str ak))]
+    (.write w (if-let [ns-info (:ns-info ak)]
+                (kw-spec-link s (:kw ak) ns-info)
+                s))))
+
+(defn- format-spec-with-links [project curr-ns spec-form]
+  (let [ns-abbrevs (-> (:ns-aliases project {})
+                       (assoc curr-ns ""))
+        info-by-ns (zipmap (map :name (:namespaces project))
+                           (:namespaces project))]
+    (pr-str
+      (walk/postwalk
+        (fn [form]
+          (if (and (keyword? form) (namespace form))
+            (let [ns (-> form namespace symbol)]
+              (->AbbrKeywordLink form (ns-abbrevs ns) (info-by-ns ns)))
+            form))
+        spec-form))))
+
+(defn- mark-up-spec [project namespace form]
+  (let [f (fn [form]
+            [:code
+              (format-spec-with-links project (:name namespace) form)])]
+    (if (or (:args form) (:ret form))
+      [:dl
+       (when (:args form) (list [:dt "args"] [:dd (f (:args form))]))
+       (when (:ret form) (list [:dt "ret"] [:dd (f (:ret form))]))
+       (when (:fn form) (list [:dt "fn"] [:dd (f (:fn form))]))]
+      (f form))))
+
 (defn- var-docs [project namespace var]
   [:div.public.anchor {:id (h (var-id (:name var)))}
    [:h3 (h (:name var))]
@@ -395,6 +450,9 @@
     (for [form (var-usage var)]
       [:code (h (pr-str form))])]
    [:div.doc (format-docstring project namespace var)]
+   (if-let [spec-form (:spec var)]
+     [:div.spec
+      (mark-up-spec project namespace spec-form)])
    (if-let [members (seq (:members var))]
      [:div.members
       [:h4 "members"]
@@ -405,6 +463,12 @@
      (if (:path var)
        [:div.src-link (link-to (var-source-uri project var) "view source")]
        (println "Could not generate source link for" (:name var))))])
+
+(defn- kw-spec-docs [project namespace kw-spec]
+  [:div.public.anchor {:id (h (spec-id (:name kw-spec)))}
+   [:h3 (h (str "::" (:name kw-spec)))]
+   [:div.spec
+    (mark-up-spec project namespace (:spec kw-spec))]])
 
 (defn- namespace-page [project namespace]
   (html5
@@ -420,7 +484,11 @@
      (added-and-deprecated-docs namespace)
      [:div.doc (format-docstring project nil namespace)]
      (for [var (sorted-public-vars namespace)]
-       (var-docs project namespace var))]]))
+       (var-docs project namespace var))
+     (when (seq (:kw-specs namespace))
+       [:h2#specs.anchor "Specs"])
+     (for [kw-spec (:kw-specs namespace)]
+       (kw-spec-docs project namespace kw-spec))]]))
 
 (defn- mkdirs [output-dir & dirs]
   (doseq [dir dirs]

--- a/example/project.clj
+++ b/example/project.clj
@@ -28,6 +28,9 @@
                            [org.clojure/clojurescript "1.7.189"]]
             :codox {:language :clojurescript}}
    :om     {:dependencies [[org.omcljs/om "0.8.8"]]}
+   :spec   {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]
+            :source-paths ^:replace ["src-spec/clojure"]
+            :codox {:ns-aliases {codox.example-spec ex}}}
    :typed  {:dependencies [[org.clojure/clojure "1.7.0"]
                            [org.clojure/core.typed "0.3.22"]]
             :plugins [[lein-typed "0.3.5"]]

--- a/example/resources/codox/theme/test/css/default.css
+++ b/example/resources/codox/theme/test/css/default.css
@@ -393,6 +393,14 @@ h4.deprecated {
     padding-left: 0;
 }
 
+.spec {
+    clear: both;
+}
+
+.spec dt {
+    font-weight: bold;
+}
+
 .type-sig {
     clear: both;
     color: #088;

--- a/example/src-spec/clojure/codox/example_spec.clj
+++ b/example/src-spec/clojure/codox/example_spec.clj
@@ -1,0 +1,50 @@
+(ns codox.example-spec
+  "For testing clojure.spec support in Codox.
+
+  Examples copied from clojure.spec guide http://clojure.org/guides/spec"
+  (:require [clojure.spec :as s]
+            [clojure.spec.gen :as gen]))
+
+(s/def ::kw-with-ns-alias (s/or :string string?
+                                :kw keyword?))
+
+(defn ranged-rand
+  "Returns random int in range start <= rand < end"
+  [start end]
+  (+ start (long (rand (- end start)))))
+
+(s/fdef ranged-rand
+  :args (s/and (s/cat :start int? :end int?)
+               #(< (:start %) (:end %)))
+  :ret int?
+  :fn (s/and #(>= (:ret %) (-> % :args :start))
+             #(< (:ret %) (-> % :args :end))))
+
+(defn adder [x] #(+ x %))
+
+(s/fdef adder
+  :args (s/cat :x number?)
+  :ret (s/fspec :args (s/cat :y number?)
+                :ret number?)
+  :fn #(= (-> % :args :x) ((:ret %) 0)))
+
+(s/def :event/type keyword?)
+(s/def :event/timestamp int?)
+(s/def :search/url string?)
+(s/def :error/message string?)
+(s/def :error/code int?)
+
+(defmulti event-type :event/type)
+(defmethod event-type :event/search [_]
+  (s/keys :req [:event/type :event/timestamp :search/url]))
+(defmethod event-type :event/error [_]
+  (s/keys :req [:event/type :event/timestamp :error/message :error/code]))
+
+(s/def :event/event (s/multi-spec event-type :event/type))
+
+(s/def ::kws (s/with-gen (s/and keyword? #(= (namespace %) "my.domain"))
+               #(s/gen #{:my.domain/name :my.domain/occupation :my.domain/id})))
+
+(s/def ::the-aughts (s/inst-in #inst "2000" #inst "2010"))
+
+(s/def ::dubs (s/double-in :min -100.0 :max 100.0 :NaN? false :infinite? false))

--- a/example/src-spec/clojure/codox/example_spec_link.clj
+++ b/example/src-spec/clojure/codox/example_spec_link.clj
@@ -1,0 +1,10 @@
+(ns codox.example-spec-link
+  "Example with clojure.spec keyword links across namespaces."
+  (:require [codox.example-spec :as ex]
+            [clojure.spec :as s]))
+
+(s/def ::local-kw (s/nilable (s/int-in 2 5)))
+
+(s/def ::some-links (s/keys :req [::local-kw
+                                  ::ex/kw-with-ns-alias
+                                  :codox.example2/kw-without-ns-alias]))


### PR DESCRIPTION
Fixes #128 

Look up registered specs on public vars, and also list specs registered by keyword in each namespace. Those keyword specs are listed in a separate section below the public vars.

One notable thing about this implementation is that I added an option to supply namespace aliases to abbreviate keywords. Also spec keywords within specs are hyperlinked.

I bumped the clojure dependency to 1.9.0-alpha10 to get `clojure.spec`. Not sure if that's a problem (seems ok to me as a dev dependency).

If you are ok with the approach I can add clojurescript support - it should be identical.
