### PR TITLE
Instructions for live documentation with KLIPSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,38 @@ vars its documenting.
   [x])
 ```
 
+## Live Documentation
+
+You can make your documentation live and interactive with the 
+[KLIPSE plugin](https://github.com/viebel/klipse), by including the 
+`:klipse` theme in your `project.clj`.
+
+Lets' say your github user is `my_user` and your repo is `my_repo`, 
+with namespace `my_repo.my_ns` with a function `my_func`, then add 
+the following options to `:codox`:
+
+```clojure
+ :codox {:metadata {:doc/format :markdown}
+         :output-path "docs"
+         :themes [:default [:klipse
+         {:klipse/external-libs
+         "https://raw.githubusercontent.com/my_user/my_repo/master/src/"
+          :klipse/require-statement
+          "(ns my.test
+          (:require [my_repo.my_ns :as my_ns :refer [my_func]]))"]]
+         }
+```
+
+And in the docstring of `my_ns/my_func`, add the code examples like this:
+
+    ~~~klipse
+    (my_func 1 2 3)
+    ~~~
+
+(`~~~klipse` creates a code block with `class="klipse"`.)
+
+Take a look at how it is done in the
+[gadjett library](https://github.com/viebel/gadjett).
 
 ## License
 

--- a/codox/resources/codox/theme/klipse/theme.edn
+++ b/codox/resources/codox/theme/klipse/theme.edn
@@ -1,0 +1,25 @@
+{:transforms
+ [[:body]
+  [:prepend
+   [:link
+    {:rel "stylesheet"
+     :type "text/css"
+     :href "https://storage.googleapis.com/app.klipse.tech/css/codemirror.css"}]
+   [:div {:style "visibility: hidden;"}
+    [:div {:class "klipse"
+           :data-external-libs :klipse/external-libs}
+     :klipse/require-statement]]]
+  [:body]
+  [:append
+   [:script
+    "window.klipse_settings = {
+    selector: '.klipse',
+    codemirror_options_in: {
+    lineWrapping: true,
+    autoCloseBrackets: true
+    },
+    codemirror_options_out: {
+    lineWrapping: true
+    }
+    };"]
+   [:script {:src "https://storage.googleapis.com/app.klipse.tech/plugin/js/klipse_plugin.js"}]]]}


### PR DESCRIPTION
Codox really rocks.

I've been able to integrate [KLIPSE](https://github.com/viebel/klipse) for  live documentation on my [gadjett library] (https://github.com/viebel/gadjett) in less than an hour.

Take a look at the result here: http://viebel.github.io/gadjett/gadjett.collections.html#var-sequence-.3Emap

(It takes a couple of seconds to load the code at run-time!)

Codox is simple and highly configurable making it really smooth to tweak.

Please review the instructions that I've written.

I believe there should be a simpler way to integrate Klipse with Codox - especially around the `:require` statement that is currently created manually with the names of all the functions of the namespace (in `ClojureScript`, there is no way to refer all the namespace public vars).

