### PR TITLE
Add license link to index page

### DIFF
--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -299,6 +299,9 @@
 (defn- add-ending [^String s ^String ending]
   (if (.endsWith s ending) s (str s ending)))
 
+(defn- strip-prefix [s prefix]
+  (if s (str/replace s (re-pattern (str "(?i)^" prefix)) "")))
+
 (defn- index-page [project]
   (html5
    [:head
@@ -309,6 +312,10 @@
     (primary-sidebar project)
     [:div#content.namespace-index
      [:h1 (project-title project)]
+     (if-let [license (-> (get-in project [:license :name]) (strip-prefix "the "))]
+       [:h5 "Released under the " (if-let [url (get-in project [:license :url])]
+                                    (link-to url license)
+                                    license)])
      (if-let [description (:description project)]
        [:div.doc [:p (h (add-ending description "."))]])
      (if-let [package (package project)]

--- a/lein-codox/src/leiningen/codox.clj
+++ b/lein-codox/src/leiningen/codox.clj
@@ -11,6 +11,7 @@
           :output-path  (str (io/file (:target-path project "target") "doc"))}
          (-> project :codox)
          {:name      (str/capitalize (:name project))
+          :license   (:license project)
           :package   (symbol (:group project) (:name project))
           :root-path (:root project)}
          (select-keys project [:version :description])


### PR DESCRIPTION
This patch looks for a non-nil `(:url project)` and adds a link into the index page. Same for `(get-in project [:license :name])`. See screenshot:

<img width="672" alt="screen shot 2016-10-16 at 17 22 48" src="https://cloud.githubusercontent.com/assets/1915543/19419067/8cbaf07a-93c7-11e6-94ba-a1f0d7ce1688.png">
