### PR TITLE
Optionally add source-code URL on index page

### DIFF
--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -312,6 +312,8 @@
     (primary-sidebar project)
     [:div#content.namespace-index
      [:h1 (project-title project)]
+     (if-let [scm-url (get-in project [:scm :url])]
+       [:a {:href scm-url :title "Source code repository"} scm-url])
      (if-let [license (-> (get-in project [:license :name]) (strip-prefix "the "))]
        [:h5.license
         "Released under the "

--- a/example/project.clj
+++ b/example/project.clj
@@ -7,6 +7,7 @@
   :plugins [[lein-codox "0.10.1"]]
   :source-paths ["src/clojure"]
   :target-path "target/%s/"
+  :scm {:url "http://example.com/SCM-FIXME"}
   :codox
   {:project {:name "Example Project", :version "1.0.0"}
    :metadata {:doc "FIXME: write docs"}

--- a/lein-codox/src/leiningen/codox.clj
+++ b/lein-codox/src/leiningen/codox.clj
@@ -13,6 +13,7 @@
          {:name      (str/capitalize (:name project))
           :license   (:license project)
           :package   (symbol (:group project) (:name project))
+          :scm       (:scm project)
           :root-path (:root project)}
          (select-keys project [:version :description])
          (-> project :codox :project)))


### PR DESCRIPTION
If leiningen project has a {:scm {:url "http://somewhere.com/path"} then that link is displayed on the index page directly under the main header. See screenshot:
<img width="669" alt="screen shot 2016-10-16 at 19 33 00" src="https://cloud.githubusercontent.com/assets/1915543/19419881/7d474934-93d8-11e6-8437-2421548ddb19.png">
