### PR TITLE
Support defaults in themes

### DIFF
--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -453,11 +453,12 @@
     (str "codox/theme/" (name theme-name))))
 
 (defn- insert-params [theme-data theme]
-  (if (and (vector? theme) (second theme))
-    (let [[_ params] theme]
-      (assert (map? params) "Theme parameters must be a map")
-      (walk/postwalk #(if (keyword? %) (params % %) %) theme-data))
-    theme-data))
+  (let [params   (if (vector? theme) (or (second theme) {}) {})
+        defaults (:defaults theme-data {})]
+    (assert (map? params) "Theme parameters must be a map")
+    (assert (map? defaults) "Theme defaults must be a map")
+    (->> (dissoc theme-data :defaults)
+         (walk/postwalk #(if (keyword? %) (params % (defaults % %)) %)))))
 
 (defn- read-theme [theme]
   (some-> (theme-path theme)


### PR DESCRIPTION
Allow the theme data to include default values using `:theme-defaults` key. This key is `dissoc`ed when the theme data is passed to codox.

I need this feature for the [klipse codox theme](https://github.com/viebel/codox-klipse-theme) in order to allow the user to define the klipse selector - but I want to keep the possibility to have a default value.

This is how the theme data will look like for klipse codox theme with the default values:

```clojure
{:theme-defaults {:klipse/selector ".klipse"}
 :transforms
 [[:body]
  [:prepend
   [:link
    {:rel "stylesheet"
     :type "text/css"
     :href "https://storage.googleapis.com/app.klipse.tech/css/codemirror.css"}]
   [:div {:style "visibility: hidden;"}
    [:div {:class "klipse"
           :data-external-libs :klipse/external-libs}
     :klipse/require-statement]]]
  [:body]
  [:append
   [:script
    ("window.klipse_settings = {
    selector: " "'" :klipse/selector "',
    codemirror_options_in: {
    lineWrapping: true,
    autoCloseBrackets: true
    },
    codemirror_options_out: {
    lineWrapping: true
    }
    };" )]
 [:script {:src "https://storage.googleapis.com/app.klipse.tech/plugin/js/klipse_plugin.js"}]]]}
```