### PR TITLE
Add support for wikilinks alternative format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.2 (2016-11-21)
+
+* Add license link to documentation index
+* Add default values to theme variables
+
 ## 0.10.1 (2016-10-08)
 
 * Add `:exclude-vars` option for excluding vars by regex

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Include the following plugin in your `project.clj` file or your global
 profile:
 
 ```clojure
-:plugins [[lein-codox "0.10.1"]]
+:plugins [[lein-codox "0.10.2"]]
 ```
 
 Then run:
@@ -28,7 +28,7 @@ This will generate API documentation in the "target/doc" subdirectory
 
 Add boot-codox to your build.boot dependencies and require the namespace:
 ```
-(set-env! :dependencies '[[boot-codox "0.10.1" :scope "test"]])
+(set-env! :dependencies '[[boot-codox "0.10.2" :scope "test"]])
 (require '[codox.boot :refer [codox]])
 ```
 

--- a/boot-codox/project.clj
+++ b/boot-codox/project.clj
@@ -1,4 +1,4 @@
-(defproject boot-codox "0.10.1"
+(defproject boot-codox "0.10.2"
   :description "Codox Boot task"
   :url "https://github.com/weavejester/codox"
   :scm {:dir ".."}

--- a/boot-codox/src/codox/boot.clj
+++ b/boot-codox/src/codox/boot.clj
@@ -6,7 +6,7 @@
             [boot.util :as util]))
 
 (defn- pod-deps []
-  (remove pod/dependency-loaded? '[[codox "0.10.1"]]))
+  (remove pod/dependency-loaded? '[[codox "0.10.2"]]))
 
 (defn- init [fresh-pod]
   (pod/require-in fresh-pod '[codox.main]))

--- a/codox/project.clj
+++ b/codox/project.clj
@@ -1,4 +1,4 @@
-(defproject codox "0.10.1"
+(defproject codox "0.10.2"
   :description "Generate documentation from Clojure source files"
   :url "https://github.com/weavejester/codox"
   :scm {:dir ".."}

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -86,6 +86,12 @@
       (if-let [var (util/search-vars (:namespaces project) text (:name ns))]
         (str (namespace var) ".html#" (var-id var))))))
 
+(defn- parse-wikilink [text]
+  (let [pos (.indexOf text "|")]
+    (if (>= pos 0)
+      [(subs text 0 pos) (subs text (inc pos))]
+      [text text])))
+
 (defn- absolute-url? [url]
   (re-find #"^([a-z]+:)?//" url))
 
@@ -104,8 +110,8 @@
     (render
       ([node]
        (if (instance? WikiLinkNode node)
-         (let [text (.getText node)]
-           (LinkRenderer$Rendering. (find-wikilink project ns text) text))
+         (let [[page text] (parse-wikilink (.getText node))]
+           (LinkRenderer$Rendering. (find-wikilink project ns page) text))
          (proxy-super render node)))
       ([node text]
        (if (instance? ExpLinkNode node)

--- a/example/build.boot
+++ b/example/build.boot
@@ -1,6 +1,6 @@
 (set-env!
   :source-paths #{"src/clojure"}
-  :dependencies '[[boot-codox "0.10.1"]])
+  :dependencies '[[boot-codox "0.10.2"]])
 
 (require '[codox.boot :refer [codox]])
 

--- a/example/project.clj
+++ b/example/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]]
-  :plugins [[lein-codox "0.10.1"]]
+  :plugins [[lein-codox "0.10.2"]]
   :source-paths ["src/clojure"]
   :target-path "target/%s/"
   :codox

--- a/example/src/clojure/codox/markdown.clj
+++ b/example/src/clojure/codox/markdown.clj
@@ -39,7 +39,7 @@
 
   foo | bar
   ----|----
-   1  |  2 
+   1  |  2
    3  |  4
 
   Definition lists:
@@ -55,7 +55,8 @@
     terms in a definition list can have definitions that span multiple lines.
 
   We can also use wikilinks to reference existing vars, like [[example/foo]] or
-  the [[Foop]] protocol, or to reference namespaces, like [[codox.example]].
+  the [[Foop]] protocol, or to reference namespaces, like [[codox.example]], and
+  optionally customize the link text, like this [[codox.example|link]].
 
   Any abbreviations, like HTML or HTTP, that have corresponding abbreviations,
   will be marked with `<abbr>` tags.

--- a/lein-codox/project.clj
+++ b/lein-codox/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-codox "0.10.1"
+(defproject lein-codox "0.10.2"
   :description "Codox Leiningen plugin"
   :url "https://github.com/weavejester/codox"
   :scm {:dir ".."}

--- a/lein-codox/src/leiningen/codox.clj
+++ b/lein-codox/src/leiningen/codox.clj
@@ -25,7 +25,7 @@
                   project)
         options (get-options project)]
     (eval/eval-in-project
-     (deps/add-if-missing project '[codox "0.10.1"])
+     (deps/add-if-missing project '[codox "0.10.2"])
      `(codox.main/generate-docs '~options)
      `(require 'codox.main))
     (main/info "Generated HTML docs in" (:output-path options))))


### PR DESCRIPTION
Specifically `[[page|text]]`. More or less ports pegdown's behavior for this, from [here](https://github.com/sirthias/pegdown/blob/2a514555a84f56fe112155748fc24d84046e9c88/src/main/java/org/pegdown/LinkRenderer.java#L94).

Non-breaking change. Didn't bother filing an issue first since it's small.