### PR TITLE
Allow key '{git-commit}' for source URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,12 @@ to the function's source file in the documentation, you can set the
 
 The URI is a template that may contain the following keys:
 
-* `{filepath}`  - the file path from the root of the repository
-* `{basename}`  - the basename of the file
-* `{classpath}` - the relative path of the file within the source directory
-* `{line}`      - the line number of the source file
-* `{version}`   - the version of the project
+* `{filepath}`   - the file path from the root of the repository
+* `{basename}`   - the basename of the file
+* `{classpath}`  - the relative path of the file within the source directory
+* `{line}`       - the line number of the source file
+* `{version}`    - the version of the project
+* `{git-commit}` - the Git commit id of the repository
 
 You can also assign different URI templates to different paths of your
 source tree. This is particularly useful for created source links from

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -150,17 +150,23 @@
 (defn- uri-basename [path]
   (second (re-find #"/([^/]+?)$" path)))
 
+(defn- force-replace [^String s match replacement]
+  (if (.contains s match)
+    (str/replace s match (force replacement))
+    s))
+
 (defn- var-source-uri
-  [{:keys [source-uri version]}
+  [{:keys [source-uri version git-commit]}
    {:keys [path file line]}]
   (let [path (util/uri-path path)
         uri  (if (map? source-uri) (get-source-uri source-uri path) source-uri)]
     (-> uri
-        (str/replace "{filepath}"  path)
-        (str/replace "{classpath}" (util/uri-path file))
-        (str/replace "{basename}"  (uri-basename path))
-        (str/replace "{line}"      (str line))
-        (str/replace "{version}"   version))))
+        (str/replace   "{filepath}"   path)
+        (str/replace   "{classpath}"  (util/uri-path file))
+        (str/replace   "{basename}"   (uri-basename path))
+        (str/replace   "{line}"       (str line))
+        (str/replace   "{version}"    version)
+        (force-replace "{git-commit}" git-commit))))
 
 (defn- split-ns [namespace]
   (str/split (str namespace) #"\."))

--- a/example/project.clj
+++ b/example/project.clj
@@ -35,4 +35,8 @@
             :source-paths ^:replace ["src-typed/clojure"]}
    :no-src {:codox ^:replace {}}
    :no-doc {:codox {:doc-paths ^:replace []}}
-   :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}})
+   :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
+   :git-commit
+   {:codox
+    {:source-uri
+     "https://github.com/weavejester/codox/blob/{git-commit}/example/{filepath}#L{basename}-{line}"}}})


### PR DESCRIPTION
The placeholder is replaced with the Git commit id of the repository.
Eg:
:codox
 {:source-uri
  "http://gerrit.mydomain.de/gitlist/myproject.git/blob/{git-commit-id}/{filepath}#L{line}"}

Will result in:
 http://gerrit.mydomain.de/gitlist/myproject.git/blob/17073c0db441f5550a6cdbd1e5d2143ae6f5b576/src/de/mydomain/foo/bar.clj#L23

See
https://github.com/weavejester/codox/issues/168