### PR TITLE
respect no-doc ns metadata in ClojureScript

### DIFF
--- a/codox/src/codox/reader/clojurescript.clj
+++ b/codox/src/codox/reader/clojurescript.clj
@@ -81,6 +81,7 @@
        (-> (ana/find-ns state ns-name)
            (select-keys [:name :doc])
            (update-some :doc correct-indent)
+           (merge (-> ns-name meta (select-keys [:no-doc])))
            (assoc :publics (read-publics state ns-name file)))})
     (catch Exception e
       (exception-handler e file))))
@@ -126,5 +127,6 @@
                     (map file-reader)
                     (apply merge)
                     (vals)
+                    (remove :no-doc)
                     (sort-by :name))))
            paths)))


### PR DESCRIPTION
The ClojureScript reader currently returns namespaces with `no-doc` metadata, this PR fixes that.

via https://github.com/martinklepsch/cljdoc/issues/74