### PR TITLE
Support managed dependencies

### DIFF
--- a/lein-codox/project.clj
+++ b/lein-codox/project.clj
@@ -5,5 +5,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
-  :dependencies [[leinjacker "0.4.2"]
+  :dependencies [[leinjacker "0.4.3"]
                  [org.clojure/core.unify "0.5.7"]])


### PR DESCRIPTION
This fixes #166 by bumping to the newly released [`leinjacker 0.4.3`](https://github.com/sattvik/leinjacker/releases/tag/0.4.3) that now includes support for managed dependencies.