### PR TITLE
Allow version to be nil when setting source-uri

### DIFF
--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -165,7 +165,7 @@
         (str/replace   "{classpath}"  (util/uri-path file))
         (str/replace   "{basename}"   (uri-basename path))
         (str/replace   "{line}"       (str line))
-        (str/replace   "{version}"    version)
+        (str/replace   "{version}"    (str version))
         (force-replace "{git-commit}" git-commit))))
 
 (defn- split-ns [namespace]


### PR DESCRIPTION
```
Exception in thread "main" java.lang.NullPointerException
	at java.lang.String.replace(String.java:2240)
	at clojure.string$replace.invokeStatic(string.clj:104)
	at clojure.string$replace.invoke(string.clj:75)
	at codox.writer.html$var_source_uri.invokeStatic(html.clj:168)
	at codox.writer.html$var_source_uri.invoke(html.clj:158)
	at codox.writer.html$var_docs.invokeStatic(html.clj:427)
	at codox.writer.html$var_docs.invoke(html.clj:404)
	at codox.writer.html$namespace_page$iter__3066__3070$fn__3071.invoke(html.clj:431)
        [...]
```

To reproduce, run:

```clj
(require 'codox.main)

(codox.main/generate-docs
  {:name "example"  
   :source-uri "https://..."})  
```

Relevant line of code: https://github.com/weavejester/codox/blob/f1f7e169bb538a1dfa50a151b281af617037956d/codox/src/codox/writer/html.clj#L168

While typical projects do have a version, some (Clojure CLI, or other direct Codox users) do not. `var-source-uri` assumes that `version` is not nil. Attached patch resolves this issue by wrapping `version` into `str`.