### PR TITLE
Lint the code with clj-kondo

### DIFF
--- a/codox/src/codox/main.clj
+++ b/codox/src/codox/main.clj
@@ -1,10 +1,10 @@
 (ns codox.main
   "Main namespace for generating documentation"
-  (:use [codox.utils :only (add-source-paths)])
-  (:require [clojure.string :as str]
-            [clojure.java.shell :as shell]
+  (:require [clojure.java.shell :as shell]
+            [clojure.string :as str]
             [codox.reader.clojure :as clj]
-            [codox.reader.plaintext :as text]))
+            [codox.reader.plaintext :as text]
+            [codox.utils :refer [add-source-paths]]))
 
 (defn- writer [{:keys [writer]}]
   (let [writer-sym (or writer 'codox.writer.html/write-docs)

--- a/codox/src/codox/main.clj
+++ b/codox/src/codox/main.clj
@@ -28,7 +28,7 @@
        (remove (comp empty? :publics))))
 
 (defn- merge-namespaces [namespaces]
-  (for [[name namespaces] (group-by :name namespaces)]
+  (for [[_ namespaces] (group-by :name namespaces)]
     (assoc (first namespaces) :publics (mapcat :publics namespaces))))
 
 (defn- cljs-read-namespaces [paths read-opts]

--- a/codox/src/codox/reader/clojure.clj
+++ b/codox/src/codox/reader/clojure.clj
@@ -65,7 +65,7 @@
 
 (defn core-typed-type [var]
   (let [{:keys [delayed-errors ret]} (typecheck-var var)]
-    (if (empty? delayed-errors)
+    (when (empty? delayed-errors)
       (:t ret))))
 
 (defn- read-var [vars var]
@@ -74,7 +74,7 @@
                     :added :deprecated :doc/format])
       (update-some :doc correct-indent)
       (assoc-some  :type (var-type var)
-                   :type-sig (if (core-typed?) (core-typed-type var))
+                   :type-sig (when (core-typed?) (core-typed-type var))
                    :members (seq (map (partial read-var vars)
                                       (protocol-methods var vars))))))
 

--- a/codox/src/codox/reader/clojure.clj
+++ b/codox/src/codox/reader/clojure.clj
@@ -2,10 +2,10 @@
   "Read raw documentation information from Clojure source directory."
   (:import java.util.jar.JarFile
            java.io.FileNotFoundException)
-  (:use [codox.utils :only (assoc-some update-some correct-indent)])
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.tools.namespace.find :as ns]
-            [clojure.string :as str]))
+            [codox.utils :refer (assoc-some correct-indent update-some)]))
 
 (defn try-require [namespace]
   (try

--- a/codox/src/codox/reader/clojurescript.clj
+++ b/codox/src/codox/reader/clojurescript.clj
@@ -23,11 +23,11 @@
   (let [len (inc (count (.getPath parent)))]
     (fn [child]
       (let [child-name (.getPath child)]
-        (if (>= (count child-name) len)
+        (when (>= (count child-name) len)
           (io/file (subs child-name len)))))))
 
 (defn- find-files [file]
-  (if (.isDirectory file)
+  (when (.isDirectory file)
     (->> (file-seq file)
          (filter cljs-file?)
          (keep (strip-parent file)))))

--- a/codox/src/codox/reader/clojurescript.clj
+++ b/codox/src/codox/reader/clojurescript.clj
@@ -1,10 +1,10 @@
 (ns codox.reader.clojurescript
   "Read raw documentation information from ClojureScript source directory."
-  (:use [codox.utils :only [assoc-some update-some correct-indent]])
-  (:require [clojure.java.io :as io]
-            [cljs.analyzer :as an]
+  (:require [cljs.analyzer :as an]
             [cljs.analyzer.api :as ana]
-            [clojure.string :as str]))
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [codox.utils :refer [assoc-some correct-indent update-some]]))
 
 (defn- cljs-filename? [filename]
   (or (.endsWith filename ".cljs")

--- a/codox/src/codox/utils.clj
+++ b/codox/src/codox/utils.clj
@@ -19,7 +19,7 @@
   (assoc-some m k (apply f (m k) args)))
 
 (defn- find-minimum [coll]
-  (if (seq coll)
+  (when (seq coll)
     (apply min coll)))
 
 (defn- find-smallest-indent [text]
@@ -34,7 +34,7 @@
    `codox.reader/read-namespaces`), and a sequence of source directory paths,
    returns a File object indicating the file from the repo root."
   [file sources]
-  (if (and file (not (.isAbsolute (io/file file))))
+  (when (and file (not (.isAbsolute (io/file file))))
     (->> (map #(io/file % file) sources)
          (filter #(.exists %))
          first)))
@@ -51,7 +51,7 @@
             (str/join "\n")))))
 
 (defn correct-indent [text]
-  (if text
+  (when text
     (let [lines (str/split-lines text)]
       (->> (rest lines)
            (str/join "\n")
@@ -87,7 +87,7 @@
    character to the first page break (\f) character OR the first TWO
    newlines."
   [s]
-  (if s
+  (when s
     (->> (str/trim s)
          (re-find #"(?s).*?(?=\f)|.*?(?=\n\n)|.*"))))
 
@@ -105,7 +105,7 @@
 (defn re-escape
   "Escape a string so it can be safely placed in a regex."
   [s]
-  (str/escape s #(if (re-chars %) (str \\ %))))
+  (str/escape s #(when (re-chars %) (str \\ %))))
 
 (defn search-vars
   "Find the best-matching var given a partial var string, a list of namespaces,

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -1,7 +1,6 @@
 (ns codox.writer.html
   "Documentation writer that outputs HTML."
   (:import [java.net URLEncoder]
-           [java.io File]
            [org.pegdown
             PegDownProcessor Extensions FastEncoder
             LinkRenderer LinkRenderer$Rendering]
@@ -52,12 +51,12 @@
   #"((https?|ftp|file)://[-A-Za-z0-9+()&@#/%?=~_|!:,.;]+[-A-Za-z0-9+()&@#/%=~_|])")
 
 (defn- add-anchors [text]
-  (if text
+  (when text
     (str/replace text url-regex "<a href=\"$1\">$1</a>")))
 
 (defmulti format-docstring
   "Format the docstring of a var or namespace into HTML."
-  (fn [project ns var] (:doc/format var))
+  (fn [_ _ var] (:doc/format var))
   :default :plaintext)
 
 (defmethod format-docstring :plaintext [_ _ metadata]
@@ -356,7 +355,7 @@
 
 (defmulti format-document
   "Format a document into HTML."
-  (fn [project doc] (:format doc)))
+  (fn [_ doc] (:format doc)))
 
 (defmethod format-document :markdown [project doc]
   [:div.markdown (.markdownToHtml pegdown (:content doc) (link-renderer project))])
@@ -442,10 +441,6 @@
      [:div.doc (format-docstring project namespace namespace)]
      (for [var (sorted-public-vars namespace)]
        (var-docs project namespace var))]]))
-
-(defn- mkdirs [output-dir & dirs]
-  (doseq [dir dirs]
-    (.mkdirs (io/file output-dir dir))))
 
 (defn- write-index [output-dir project]
   (spit (io/file output-dir "index.html") (transform-html project (index-page project))))

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -1,6 +1,5 @@
 (ns codox.writer.html
   "Documentation writer that outputs HTML."
-  (:use [hiccup core page element])
   (:import [java.net URLEncoder]
            [java.io File]
            [org.pegdown
@@ -12,9 +11,10 @@
             [clojure.pprint :as pp]
             [clojure.string :as str]
             [clojure.walk :as walk]
+            [codox.utils :as util]
+            [hiccup.core :refer [h html5 link-to unordered-list]]
             [net.cgrand.enlive-html :as enlive-html]
-            [net.cgrand.jsoup :as jsoup]
-            [codox.utils :as util]))
+            [net.cgrand.jsoup :as jsoup]))
 
 (def enlive-operations
   {:append     enlive-html/append

--- a/codox/src/codox/writer/html.clj
+++ b/codox/src/codox/writer/html.clj
@@ -144,7 +144,7 @@
   (str (ns-filename namespace) "#" (var-id (:name var))))
 
 (defn- get-source-uri [source-uris path]
-  (some (fn [[re f]] (if (re-find re path) f)) source-uris))
+  (some (fn [[re f]] (when (re-find re path) f)) source-uris))
 
 (defn- uri-basename [path]
   (second (re-find #"/([^/]+?)$" path)))
@@ -216,11 +216,11 @@
        [:span.top {:style (str "height: " height "px;")}]
        [:span.bottom]])))
 
-(defn- index-link [project on-index?]
+(defn- index-link [_ on-index?]
   (list
    [:h3.no-link [:span.inner "Project"]]
    [:ul.index-link
-    [:li.depth-1 {:class (if on-index? "current")}
+    [:li.depth-1 {:class (when on-index? "current")}
      (link-to "index.html" [:div.inner "Index"])]]))
 
 (defn- topics-menu [project current-doc]
@@ -230,18 +230,18 @@
      [:ul
       (for [doc docs]
         [:li.depth-1
-         {:class (if (= doc current-doc) " current")}
+         {:class (when (= doc current-doc) " current")}
          (link-to (doc-filename doc) [:div.inner [:span (h (:title doc))]])])])))
 
 (defn- nested-namespaces [namespaces current-ns]
   (let [ns-map (index-by :name namespaces)]
     [:ul
       (for [[name depth height branch?] (namespace-hierarchy namespaces)]
-        (let [class  (str "depth-" depth (if branch? " branch"))
+        (let [class  (str "depth-" depth (when branch? " branch"))
               short  (last (split-ns name))
               inner  [:div.inner (ns-tree-part height) [:span (h short)]]]
           (if-let [ns (ns-map name)]
-            (let [class (str class (if (= ns current-ns) " current"))]
+            (let [class (str class (when (= ns current-ns) " current"))]
               [:li {:class class} (link-to (ns-filename ns) inner)])
             [:li {:class class} [:div.no-link inner]])))]))
 
@@ -249,7 +249,7 @@
   [:ul
    (for [ns (sort-by :name namespaces)]
      [:li.depth-1
-      {:class (if (= ns current-ns) "current")}
+      {:class (when (= ns current-ns) "current")}
       (link-to (ns-filename ns) [:div.inner [:span (h (:name ns))]])])])
 
 (defn- namespace-list-type [project]
@@ -311,7 +311,7 @@
   (if (.endsWith s ending) s (str s ending)))
 
 (defn- strip-prefix [s prefix]
-  (if s (str/replace s (re-pattern (str "(?i)^" prefix)) "")))
+  (when s (str/replace s (re-pattern (str "(?i)^" prefix)) "")))
 
 (defn- index-page [project]
   (html5
@@ -380,7 +380,7 @@
    (if-let [added (:added var)]
      [:h4.added "added in " added])
    (if-let [deprecated (:deprecated var)]
-     [:h4.deprecated "deprecated" (if (string? deprecated) (str " in " deprecated))])))
+     [:h4.deprecated "deprecated" (when (string? deprecated) (str " in " deprecated))])))
 
 (defn- remove-namespaces [x namespaces]
   (if (and (symbol? x) (contains? namespaces (namespace x)))
@@ -405,10 +405,10 @@
    [:h3 (h (:name var))]
    (if-not (= (:type var) :var)
      [:h4.type (name (:type var))])
-   (if (:dynamic var)
+   (when (:dynamic var)
      [:h4.dynamic "dynamic"])
    (added-and-deprecated-docs var)
-   (if (:type-sig var)
+   (when (:type-sig var)
      [:div.type-sig
       [:pre (h (type-sig namespace var))]])
    [:div.usage
@@ -421,7 +421,7 @@
       [:div.inner
        (let [project (dissoc project :source-uri)]
          (map (partial var-docs project namespace) members))]])
-   (if (:source-uri project)
+   (when (:source-uri project)
      (if (:path var)
        [:div.src-link (link-to (var-source-uri project var) "view source")]
        (println "Could not generate source link for" (:name var))))])


### PR DESCRIPTION
Hi @weavejester 

It's basically a cosmetic PR where I used [clj-kondo](https://github.com/borkdude/clj-kondo) on the source code before sending a feature PR that will follow soon.

`clj-kondo` uses Batsov's [Clojure Style Guide](https://github.com/bbatsov/clojure-style-guide), as defined in CONTRIBUTING guidelines.

Thank you very much, and also all the collaborators, for such awesome tool.