### PR TITLE
Migrate to flexmark (not mergeable - for reference only)

### DIFF
--- a/codox/.gitignore
+++ b/codox/.gitignore
@@ -1,0 +1,1 @@
+test/doc

--- a/codox/java/codox/LinkResolverFactoryImpl.java
+++ b/codox/java/codox/LinkResolverFactoryImpl.java
@@ -1,0 +1,31 @@
+package codox;
+
+
+import com.vladsch.flexmark.html.LinkResolverFactory;
+import com.vladsch.flexmark.html.renderer.LinkResolverBasicContext;
+import com.vladsch.flexmark.html.LinkResolver;
+import clojure.lang.IFn;
+import java.util.Set;
+
+
+public class LinkResolverFactoryImpl implements LinkResolverFactory {
+  public final Set afterDeps;
+  public final Set beforeDeps;
+  public final boolean affectsGlobalScope;
+  public final IFn resolverFn;
+
+  public LinkResolverFactoryImpl(Set _afterDeps, Set _beforeDeps, boolean ags,
+				 IFn _resolverFn) {
+    afterDeps = _afterDeps;
+    beforeDeps = _beforeDeps;
+    affectsGlobalScope = ags;
+    resolverFn = _resolverFn;
+  }
+
+  public Set<Class<?>> getAfterDependents() { return afterDeps; }  
+  public Set<Class<?>> getBeforeDependents() { return beforeDeps; }
+  public boolean affectsGlobalScope() { return affectsGlobalScope; }
+  public LinkResolver apply(LinkResolverBasicContext context) {
+    return (LinkResolver)resolverFn.invoke(context);
+  }
+}

--- a/codox/project.clj
+++ b/codox/project.clj
@@ -1,13 +1,14 @@
-(defproject codox "0.10.7"
-  :description "Generate documentation from Clojure source files"
-  :url "https://github.com/weavejester/codox"
+(defproject com.cnuernber/codox "1.00-SNAPSHOT"
+  :description "Generate documentation from Clojure source files - forked from
+weavejester's codox and upgraded to use flexmark-java instead of pegdown."
+  :url "https://github.com/cnuernber/codox"
   :scm {:dir ".."}
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/tools.namespace "0.2.11"]
-                 [org.clojure/clojurescript "1.7.189"]
+  :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]
+                 [org.clojure/tools.namespace "1.1.0"]
                  [hiccup "1.0.5"]
-                 [enlive "1.1.6"]
-                 [org.pegdown/pegdown "1.6.0"]
-                 [org.ow2.asm/asm-all "5.0.3"]])
+                 ;;later version of jsoup used by flexmark
+                 [enlive "1.1.6" :exclusions [org.jsoup/jsoup]]
+                 [com.vladsch.flexmark/flexmark-all "0.62.2"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.10.866"]]}})

--- a/codox/project.clj
+++ b/codox/project.clj
@@ -11,4 +11,6 @@ weavejester's codox and upgraded to use flexmark-java instead of pegdown."
                  ;;later version of jsoup used by flexmark
                  [enlive "1.1.6" :exclusions [org.jsoup/jsoup]]
                  [com.vladsch.flexmark/flexmark-all "0.62.2"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.10.866"]]}})
+  :java-source-paths ["java"]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.10.866"]]
+                   :source-paths ["src" "test/src" "test"]}})

--- a/codox/test/codox_test.clj
+++ b/codox/test/codox_test.clj
@@ -1,0 +1,16 @@
+(ns codox-test
+  (:require [codox.main :as main]))
+
+
+
+(comment
+
+  (main/generate-docs {:source-paths ["test/src"]
+                       :output-path "test/doc"
+                       :doc-paths ["test/topics"]
+                       :namespaces ['testns]
+                       :metadata {:doc/format :markdown}
+                       :source-uri "https://github.com/cnuernber/codox/blob/master/codox/{filepath}#L{line}"}
+                      )
+
+  )

--- a/codox/test/src/testns.clj
+++ b/codox/test/src/testns.clj
@@ -1,0 +1,20 @@
+(ns testns
+  "Some namespace docs!")
+
+
+(defn testvar
+  "Some documentation on the testvar.
+
+```clojure
+user> (+ 1 2)
+3
+```"
+  [a]
+  (+ a 2))
+
+
+(defn testvar2
+  "Some more documentation.
+  See [[testvar]]."
+  [a b]
+  (+ a b))

--- a/codox/test/topics/topic.md
+++ b/codox/test/topics/topic.md
@@ -1,0 +1,4 @@
+# Topic
+
+
+Some great text on an interesting topic.


### PR DESCRIPTION
Partial Fixes for:

* #197 - jdk 16 crash
* #158 - migrate to flexmark 

This PR is take it or leave it.  It may be a good starting point to continue to move this codebase forward but it does upgrade the dependencies to up-to-date versions thus most likely losing backwards compat - which is handled by the codebase in its current form.

For my use cases, having codox itself as a stand-alone deps.edn based project that can run from the command line is much more useful so my plan is to continue on my main branch removing the lein,boot plugins and moving the main codox directory up a level.  I have code in dtype-next that works for both [project.clj and deps.edn](https://github.com/cnuernber/dtype-next/blob/master/src/tech/v3/libs/lein_codox.clj) that I will move forward with.