### PR TITLE
Migrate to flexmark-java

### DIFF
--- a/codox/project.clj
+++ b/codox/project.clj
@@ -9,5 +9,7 @@
                  [org.clojure/clojurescript "1.7.189"]
                  [hiccup "1.0.5"]
                  [enlive "1.1.6"]
-                 [org.pegdown/pegdown "1.6.0"]
+                 [com.vladsch.flexmark/flexmark "0.62.2"]
+                 [com.vladsch.flexmark/flexmark-profile-pegdown "0.62.2"]
+                 [com.vladsch.flexmark/flexmark-util-misc"0.62.2"]
                  [org.ow2.asm/asm-all "5.0.3"]])


### PR DESCRIPTION
Hi,

can you please review draft patch for migrating PegDown to flexmark-java solves #158 as well as #197. I've also upgraded to latest Clojure(Script) versions while at it.

The codex/example project generates markdown docs as expected, so functionality wise the patch appears to be complete. I still need to do a bit of tidying up (around the three reification functions, there is some performance cost around it), I thought to send it out for review first to get some feedback I'm on the right track.

I went mostly out for compatibility with the existing PegDown code. The only think I don't understand and haven't ported over is the link `encode-title`. Why do we needed to encode the link title in the first place as opposed to everything else that we don't? The browser appears to display it correctly in both cases.

Tested the codox/example project to work with all Java 8, 11 and 17.

Thanks.

