### PR TITLE
Fix duplicate namespaces

### DIFF
--- a/codox/src/codox/reader/clojure.clj
+++ b/codox/src/codox/reader/clojure.clj
@@ -116,8 +116,8 @@
 
 (defn- find-namespaces [file]
   (cond
-    (.isDirectory file) (ns/find-namespaces-in-dir file)
-    (jar-file? file)    (ns/find-namespaces-in-jarfile (JarFile. file))))
+    (.isDirectory file) (set (ns/find-namespaces-in-dir file))
+    (jar-file? file)    (set (ns/find-namespaces-in-jarfile (JarFile. file)))))
 
 (defn read-namespaces
   "Read Clojure namespaces from a set of source directories (defaults


### PR DESCRIPTION
This is just an extraction of a fix from #179 for merging convenience.
As [discussed](https://github.com/weavejester/codox/pull/217#issuecomment-1622458273) at #217, for #216.

Please feel free to close if you'd rather handle at #179.

Thanks!