### PR TITLE
Adjust default theme: remove CSS shadows

### DIFF
--- a/codox/resources/codox/theme/default/css/default.css
+++ b/codox/resources/codox/theme/default/css/default.css
@@ -92,7 +92,7 @@ h5.license {
 
 #header {
     background: #3f3f3f;
-    box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
+    border-bottom: 1px solid #cccccc;
     z-index: 100;
 }
 
@@ -101,7 +101,6 @@ h5.license {
     padding: 0;
     font-size: 18px;
     font-weight: lighter;
-    text-shadow: -1px -1px 0px #333;
 }
 
 #header h1 .project-version {


### PR DESCRIPTION
Aesthetics are obviously objective, but my 2c: the current default CSS theme could probably do with a visual touch-up to help give it a more modern feel.

This isn't an area I have any particular skills in, but I'm at least proposing the removal of the drop-shadows here since this is a visual style that (IMO) comes across as a bit dated.

Please feel free to close if you disagree.

Thanks!